### PR TITLE
Remove getExceptionMessage from Validator interface. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
                     <groupId>org.testng</groupId>
                     <artifactId>testng</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.8.0-beta0</version>
+            <version>1.7.9</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.8.0-beta0</version>
+            <version>1.7.9</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,17 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.8.0-beta0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.8.0-beta0</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
 Add getExceptionMessage to AbstractValidator with SearchRule and ValidationContext as new parameters.  Add ValidationContext to ValidationResult.  Override getExceptionMessage for UniquenessLocatorValidator.
Remove validator from validationResult, fix tests